### PR TITLE
Backup and version (control) of local directory in netdump server

### DIFF
--- a/templates/netdump.dir.php
+++ b/templates/netdump.dir.php
@@ -1,0 +1,27 @@
+<?php
+
+$_TEMPLATE["netdump.dir"] = array(
+	"cmd" => "echo dummy" // Fake output
+	, "output" => "async"
+	, "cases" => array(
+		array(
+			array(
+				"dummy", "dummy", EXP_GLOB, "finish" // Expect fake output and finish
+			)
+		)
+	)
+  , "answers" => array(
+		array(
+			array(
+				"dummy", "", 1 // Write nothing
+			)
+		)
+	)
+	, "pre-exec" => array(
+	)
+	, "post-exec" => array(
+		  "test -d '/opt/netdump/ftp/" . $target_tag . "'" // Check for directory
+		, "cp -ax '/opt/netdump/ftp/" . $target_tag . "' " . escapeshellarg($gitfile_dir) // Versioning of directory
+	)
+);
+


### PR DESCRIPTION
Buen día Dayco,

Con esta plantilla se puede hacer respaldo de un directorio local del servidor del Netdump.

Por ejemplo, se colocan archivos en la ruta /opt/netdump/ftp/<directorio> y se puede realizar control de versiones con la siguientes plantilla configurandola de la siguiente manera;

netdump.dir:<directorio>:dummy:dummy

Saludos.-